### PR TITLE
[sink-input-ext] Follow mute state and don't override user changes.

### DIFF
--- a/src/policy-group.c
+++ b/src/policy-group.c
@@ -545,7 +545,7 @@ void pa_policy_group_insert_sink_input(struct userdata      *u,
                 pa_log_debug("set volume limit %d for sink input '%s'",
                              (group->limit * 100) / PA_VOLUME_NORM,sinp_name);
 
-                pa_sink_input_ext_set_volume_limit(si, group->limit);
+                pa_sink_input_ext_set_volume_limit(u, si, group->limit);
             }
         }
 
@@ -1174,7 +1174,7 @@ static int volset_group(struct userdata        *u,
         if (!group->locmute) {
             for (sl = group->sinpls;   sl != NULL;   sl = sl->next) {
                 sinp = sl->sink_input;
-                vset = pa_sink_input_ext_set_volume_limit(sinp, limit);
+                vset = pa_sink_input_ext_set_volume_limit(u, sinp, limit);
 
                 if (vset < 0)
                     retval = -1;
@@ -1324,7 +1324,7 @@ static int mute_group_locally(struct userdata        *u,
             pa_log_debug("set volume limit %d for sink input '%s'/'%s'",
                          percent, group->name, sinp_name);
 
-            if (pa_sink_input_ext_set_volume_limit(sinp, volume) < 0)
+            if (pa_sink_input_ext_set_volume_limit(u, sinp, volume) < 0)
                 ret = -1;
             else {
                 pa_log_debug("now volume limit %d for sink input '%s'/'%s'",

--- a/src/sink-input-ext.c
+++ b/src/sink-input-ext.c
@@ -31,7 +31,7 @@ static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *si, 
 
 static struct pa_policy_group* get_group(struct userdata *, const char *, pa_proplist *sinp_proplist, uint32_t *);
 static struct pa_policy_group* get_group_or_classify(struct userdata *, struct pa_sink_input *, uint32_t *);
-static void handle_new_sink_input(struct userdata *, struct pa_sink_input *, int *);
+static void handle_new_sink_input(struct userdata *, struct pa_sink_input *, int *, int *);
 static void handle_sink_input_fixate(struct userdata *u, pa_sink_input_new_data *sinp_data);
 static void handle_removed_sink_input(struct userdata *,
                                       struct pa_sink_input *);
@@ -101,7 +101,7 @@ void pa_sink_input_ext_discover(struct userdata *u)
     pa_assert_se((idxset = u->core->sink_inputs));
 
     while ((sinp = pa_idxset_iterate(idxset, &state, NULL)) != NULL)
-        handle_new_sink_input(u, sinp, NULL);
+        handle_new_sink_input(u, sinp, NULL, NULL);
 }
 
 void  pa_sink_input_ext_rediscover(struct userdata *u)
@@ -111,6 +111,7 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
     struct pa_sink_input *sinp;
     struct pa_sink_input_ext *ext;
     int                   old_corked_state;
+    int                   old_muted_state;
     const char           *group_name;
     const char           *clear[3] = { PA_PROP_POLICY_GROUP, PA_PROP_POLICY_STREAM_FLAGS, NULL };
 
@@ -128,10 +129,11 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
         pa_log_debug("rediscover sink-input \"%s\"", pa_sink_input_ext_get_name(sinp));
         pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
         old_corked_state = ext->local.corked_by_client;
+        old_muted_state = ext->local.muted_by_client;
         /* First remove sink input and then re-classify. */
         handle_removed_sink_input(u, sinp);
         pa_proplist_unset_many(sinp->proplist, clear);
-        handle_new_sink_input(u, sinp, &old_corked_state);
+        handle_new_sink_input(u, sinp, &old_corked_state, &old_muted_state);
     }
 }
 
@@ -200,7 +202,8 @@ const char *pa_sink_input_ext_get_name(struct pa_sink_input *sinp)
 }
 
 
-int pa_sink_input_ext_set_volume_limit(struct pa_sink_input *sinp,
+int pa_sink_input_ext_set_volume_limit(struct userdata *u,
+                                       struct pa_sink_input *sinp,
                                        pa_volume_t limit)
 {
     pa_sink     *sink;
@@ -218,9 +221,9 @@ int pa_sink_input_ext_set_volume_limit(struct pa_sink_input *sinp,
     retval = 0;
 
     if (limit == 0)
-        pa_sink_input_set_mute(sinp, true, true);
+        pa_sink_input_ext_mute(u, sinp, true);
     else {
-        pa_sink_input_set_mute(sinp, false, true);
+        pa_sink_input_ext_mute(u, sinp, false);
 
         if (limit > PA_VOLUME_NORM)
             limit = PA_VOLUME_NORM;
@@ -371,7 +374,7 @@ static pa_hook_result_t sink_input_put(void *hook_data, void *call_data,
     struct pa_sink_input *sinp = (struct pa_sink_input *)call_data;
     struct userdata      *u    = (struct userdata *)slot_data;
 
-    handle_new_sink_input(u, sinp, NULL);
+    handle_new_sink_input(u, sinp, NULL, NULL);
 
     return PA_HOOK_OK;
 }
@@ -460,7 +463,8 @@ static struct pa_policy_group* get_group_or_classify(struct userdata *u, struct 
 
 static void handle_new_sink_input(struct userdata      *u,
                                   struct pa_sink_input *sinp,
-                                  int *preserve_corked_by_client)
+                                  int *preserve_corked_by_client,
+                                  int *preserve_muted_by_client)
 {
     struct      pa_policy_group *group = NULL;
     struct      pa_sink_input_ext *ext;
@@ -479,7 +483,13 @@ static void handle_new_sink_input(struct userdata      *u,
         if (preserve_corked_by_client)
             ext->local.corked_by_client = *preserve_corked_by_client;
         else
-            ext->local.corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp);
+            ext->local.corked_by_client = (PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp) ?
+                                           SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
+        if (preserve_muted_by_client)
+            ext->local.muted_by_client = *preserve_muted_by_client;
+        else
+            ext->local.muted_by_client = (pa_sink_input_get_mute(sinp) ?
+                                           SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
         pa_index_hash_add(u->hsi, idx, ext);
 
         pa_policy_context_register(u, pa_policy_object_sink_input, sinp_name, sinp);
@@ -493,7 +503,34 @@ static void handle_new_sink_input(struct userdata      *u,
         pa_proplist_set(sinp->proplist, PA_PROP_POLICY_STREAM_FLAGS,
                         (void*)&flags, sizeof(flags));
 
-        pa_log_debug("new sink_input %s (idx=%u) (group=%s)", sinp_name, idx, group->name);
+        pa_log_debug("new sink_input %s (%scorked, %smuted) (idx=%u) (group=%s)",
+                     sinp_name,
+                     ext->local.corked_by_client == SINK_INPUT_EXT_TRUE ? "" : "un",
+                     ext->local.muted_by_client == SINK_INPUT_EXT_TRUE ? "" : "un",
+                     idx, group->name);
+    }
+}
+
+static void check_and_follow_state(struct userdata *u, pa_sink_input *si, struct pa_sink_input_ext *ext)
+{
+    if (!u->ssi->state) {
+        /* Check current sink input state and enable corking state and mute following. */
+        u->ssi->state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_STATE_CHANGED],
+                                        PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_state_changed, (void *) u);
+    }
+
+    if (ext->local.corked_by_client == SINK_INPUT_EXT_UNSET) {
+        ext->local.corked_by_client = (PA_SINK_INPUT_CORKED == pa_sink_input_get_state(si) ?
+                                       SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
+        pa_log_debug("initial corking state %s", ext->local.corked_by_client == SINK_INPUT_EXT_TRUE ?
+                                                 "corked" : "uncorked");
+    }
+
+    if (ext->local.muted_by_client == SINK_INPUT_EXT_UNSET) {
+        ext->local.muted_by_client = (pa_sink_input_get_mute(si) ?
+                                       SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
+        pa_log_debug("initial muting state %s", ext->local.muted_by_client == SINK_INPUT_EXT_TRUE ?
+                                                "muted" : "unmuted");
     }
 }
 
@@ -509,15 +546,10 @@ bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
 
     pa_assert_se((ext = pa_sink_input_ext_lookup(u, si)));
 
-    if (!u->ssi->state) {
-        /* Check current sink input state and enable corking state following. */
-        u->ssi->state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_STATE_CHANGED],
-                                        PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_state_changed, (void *) u);
-        ext->local.corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(si);
-    }
+    check_and_follow_state(u, si, ext);
 
     if (cork) {
-        if (!ext->local.corked_by_client) {
+        if (ext->local.corked_by_client == SINK_INPUT_EXT_FALSE) {
             ext->local.ignore_state_change = true;
             pa_log_debug("sink input wasn't already corked by client -> cork");
             pa_sink_input_cork(si, true);
@@ -525,7 +557,7 @@ bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
         } else
             pa_log_debug("sink input was already corked by client -> not corking");
     } else {
-        if (!ext->local.corked_by_client) {
+        if (ext->local.corked_by_client == SINK_INPUT_EXT_FALSE) {
             ext->local.ignore_state_change = true;
             pa_log_debug("sink input wasn't already corked by client -> uncork");
             pa_sink_input_cork(si, false);
@@ -537,10 +569,46 @@ bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
     return sink_input_corking_changed;
 }
 
+bool pa_sink_input_ext_mute(struct userdata *u, pa_sink_input *si, bool mute)
+{
+    struct pa_sink_input_ext *ext;
+    bool sink_input_muting_changed = false;
+
+    pa_assert(si);
+    pa_assert(u);
+    pa_assert(u->core);
+    pa_assert(u->ssi);
+
+    pa_assert_se((ext = pa_sink_input_ext_lookup(u, si)));
+
+    check_and_follow_state(u, si, ext);
+
+    if (mute) {
+        if (ext->local.muted_by_client == SINK_INPUT_EXT_FALSE) {
+            ext->local.ignore_state_change = true;
+            pa_log_debug("sink input wasn't already muted by client -> mute");
+            pa_sink_input_set_mute(si, true, true);
+            sink_input_muting_changed = true;
+        } else
+            pa_log_debug("sink input was already muted by client -> not muting");
+    } else {
+        if (ext->local.muted_by_client == SINK_INPUT_EXT_FALSE) {
+            ext->local.ignore_state_change = true;
+            pa_log_debug("sink input wasn't already muted by client -> unmute");
+            pa_sink_input_set_mute(si, false, true);
+            sink_input_muting_changed = true;
+        } else
+            pa_log_debug("sink input wasn't already muted by client -> not unmuting");
+    }
+
+    return sink_input_muting_changed;
+}
+
 static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *sinp, struct userdata *u)
 {
     struct pa_sink_input_ext *ext;
-    bool corked_by_client;
+    enum sink_input_ext_state corked_by_client;
+    enum sink_input_ext_state muted_by_client;
 
     pa_assert(c);
     pa_assert(sinp);
@@ -548,15 +616,25 @@ static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *sinp
 
     pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
     if (ext->local.ignore_state_change) {
-        pa_log_debug("local state change -> IGNORE");
+        pa_log_debug("ignore local state change");
+        ext->local.ignore_state_change = false;
         return PA_HOOK_OK;
     }
 
-    ext->local.ignore_state_change = false;
-    corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp);
+    corked_by_client = (PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp) ?
+                        SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
     if (corked_by_client != ext->local.corked_by_client) {
-        pa_log_debug("corked_by_client changes to %s", corked_by_client ? "true" : "false");
+        pa_log_debug("corked_by_client changes to %s (%p)",
+                corked_by_client == SINK_INPUT_EXT_TRUE ? "true" : "false",
+                sinp);
         ext->local.corked_by_client = corked_by_client;
+    }
+
+    muted_by_client = (pa_sink_input_get_mute(sinp) ? SINK_INPUT_EXT_TRUE : SINK_INPUT_EXT_FALSE);
+    if (muted_by_client != ext->local.muted_by_client) {
+        pa_log_debug("muted_by_client changes to %s (%p)",
+                muted_by_client == SINK_INPUT_EXT_TRUE ? "muted" : "unmuted");
+        ext->local.muted_by_client = muted_by_client;
     }
 
     return PA_HOOK_OK;

--- a/src/sink-input-ext.h
+++ b/src/sink-input-ext.h
@@ -20,11 +20,18 @@ struct pa_sinp_evsubscr {
     pa_hook_slot    *state;
 };
 
+enum sink_input_ext_state {
+    SINK_INPUT_EXT_UNSET = 0,
+    SINK_INPUT_EXT_TRUE,
+    SINK_INPUT_EXT_FALSE,
+};
+
 struct pa_sink_input_ext {
     struct {
         int route;
         int mute;
-        bool corked_by_client;
+        enum sink_input_ext_state corked_by_client;
+        enum sink_input_ext_state muted_by_client;
         bool ignore_state_change;
     }                local;     /* local policies */
 };
@@ -39,8 +46,10 @@ struct pa_sink_input_ext *pa_sink_input_ext_lookup(struct userdata *,
 int   pa_sink_input_ext_set_policy_group(struct pa_sink_input *, const char *);
 const char *pa_sink_input_ext_get_policy_group(struct pa_sink_input *);
 const char *pa_sink_input_ext_get_name(struct pa_sink_input *);
-int   pa_sink_input_ext_set_volume_limit(struct pa_sink_input *, pa_volume_t);
+int   pa_sink_input_ext_set_volume_limit(struct userdata *u,
+                                         struct pa_sink_input *, pa_volume_t);
 bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork);
+bool pa_sink_input_ext_mute(struct userdata *u, pa_sink_input *si, bool mute);
 
 #endif
 


### PR DESCRIPTION
Follow sink-input mute state, and don't override user mute values when
enforcing volume limits for sink-input.