### PR TITLE
Revert "[sink-input-ext] Follow mute state and don't override user changes."

### DIFF
--- a/src/policy-group.c
+++ b/src/policy-group.c
@@ -545,7 +545,7 @@ void pa_policy_group_insert_sink_input(struct userdata      *u,
                 pa_log_debug("set volume limit %d for sink input '%s'",
                              (group->limit * 100) / PA_VOLUME_NORM,sinp_name);
 
-                pa_sink_input_ext_set_volume_limit(u, si, group->limit);
+                pa_sink_input_ext_set_volume_limit(si, group->limit);
             }
         }
 
@@ -1174,7 +1174,7 @@ static int volset_group(struct userdata        *u,
         if (!group->locmute) {
             for (sl = group->sinpls;   sl != NULL;   sl = sl->next) {
                 sinp = sl->sink_input;
-                vset = pa_sink_input_ext_set_volume_limit(u, sinp, limit);
+                vset = pa_sink_input_ext_set_volume_limit(sinp, limit);
 
                 if (vset < 0)
                     retval = -1;
@@ -1324,7 +1324,7 @@ static int mute_group_locally(struct userdata        *u,
             pa_log_debug("set volume limit %d for sink input '%s'/'%s'",
                          percent, group->name, sinp_name);
 
-            if (pa_sink_input_ext_set_volume_limit(u, sinp, volume) < 0)
+            if (pa_sink_input_ext_set_volume_limit(sinp, volume) < 0)
                 ret = -1;
             else {
                 pa_log_debug("now volume limit %d for sink input '%s'/'%s'",

--- a/src/sink-input-ext.h
+++ b/src/sink-input-ext.h
@@ -20,18 +20,11 @@ struct pa_sinp_evsubscr {
     pa_hook_slot    *state;
 };
 
-enum sink_input_ext_state {
-    SINK_INPUT_EXT_UNSET = 0,
-    SINK_INPUT_EXT_TRUE,
-    SINK_INPUT_EXT_FALSE,
-};
-
 struct pa_sink_input_ext {
     struct {
         int route;
         int mute;
-        enum sink_input_ext_state corked_by_client;
-        enum sink_input_ext_state muted_by_client;
+        bool corked_by_client;
         bool ignore_state_change;
     }                local;     /* local policies */
 };
@@ -46,10 +39,8 @@ struct pa_sink_input_ext *pa_sink_input_ext_lookup(struct userdata *,
 int   pa_sink_input_ext_set_policy_group(struct pa_sink_input *, const char *);
 const char *pa_sink_input_ext_get_policy_group(struct pa_sink_input *);
 const char *pa_sink_input_ext_get_name(struct pa_sink_input *);
-int   pa_sink_input_ext_set_volume_limit(struct userdata *u,
-                                         struct pa_sink_input *, pa_volume_t);
+int   pa_sink_input_ext_set_volume_limit(struct pa_sink_input *, pa_volume_t);
 bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork);
-bool pa_sink_input_ext_mute(struct userdata *u, pa_sink_input *si, bool mute);
 
 #endif
 


### PR DESCRIPTION
This reverts commit 2cecb01a5fecb07c1d4a5d8eb42b2d75cd408eea.

Mute state following implementation is broken, and proper fix would
require more hooks. Those hooks are present in PulseAudio 6.0, so redo
the mute state following implementation after porting to PulseAudio 6.0.