### PR TITLE
Follow user mute state for sink inputs.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,4 +17,4 @@ module_policy_enforcement_la_SOURCES = \
 			dbusif.c
 module_policy_enforcement_la_LDFLAGS = -module -avoid-version
 module_policy_enforcement_la_LIBADD = $(AM_LIBADD) $(DBUS_LIBS) $(LIBPULSECORE_LIBS) $(LIBPULSE_LIBS) $(MEEGOCOMMON_LIBS)
-module_policy_enforcement_la_CFLAGS = $(AM_CFLAGS) $(DBUS_CFLAGS) $(LIBPULSE_CFLAGS) $(LIBPULSECORE_CFLAGS) $(MEEGOCOMMON_CFLAGS)
+module_policy_enforcement_la_CFLAGS = $(AM_CFLAGS) $(DBUS_CFLAGS) $(LIBPULSE_CFLAGS) $(LIBPULSECORE_CFLAGS) $(MEEGOCOMMON_CFLAGS) -DPULSEAUDIO_VERSION=@PA_MAJOR@

--- a/src/policy-group.c
+++ b/src/policy-group.c
@@ -545,7 +545,7 @@ void pa_policy_group_insert_sink_input(struct userdata      *u,
                 pa_log_debug("set volume limit %d for sink input '%s'",
                              (group->limit * 100) / PA_VOLUME_NORM,sinp_name);
 
-                pa_sink_input_ext_set_volume_limit(si, group->limit);
+                pa_sink_input_ext_set_volume_limit(u, si, group->limit);
             }
         }
 
@@ -1174,7 +1174,7 @@ static int volset_group(struct userdata        *u,
         if (!group->locmute) {
             for (sl = group->sinpls;   sl != NULL;   sl = sl->next) {
                 sinp = sl->sink_input;
-                vset = pa_sink_input_ext_set_volume_limit(sinp, limit);
+                vset = pa_sink_input_ext_set_volume_limit(u, sinp, limit);
 
                 if (vset < 0)
                     retval = -1;
@@ -1324,7 +1324,7 @@ static int mute_group_locally(struct userdata        *u,
             pa_log_debug("set volume limit %d for sink input '%s'/'%s'",
                          percent, group->name, sinp_name);
 
-            if (pa_sink_input_ext_set_volume_limit(sinp, volume) < 0)
+            if (pa_sink_input_ext_set_volume_limit(u, sinp, volume) < 0)
                 ret = -1;
             else {
                 pa_log_debug("now volume limit %d for sink input '%s'/'%s'",

--- a/src/sink-input-ext.c
+++ b/src/sink-input-ext.c
@@ -28,10 +28,14 @@ static pa_hook_result_t sink_input_fixate(void *, void *, void *);
 static pa_hook_result_t sink_input_put(void *, void *, void *);
 static pa_hook_result_t sink_input_unlink(void *, void *, void *);
 static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *si, struct userdata *u);
+#if (PULSEAUDIO_VERSION == 6)
+static pa_hook_result_t sink_input_mute_changed(pa_core *c, pa_sink_input *si, struct userdata *u);
+#endif
 
 static struct pa_policy_group* get_group(struct userdata *, const char *, pa_proplist *sinp_proplist, uint32_t *);
 static struct pa_policy_group* get_group_or_classify(struct userdata *, struct pa_sink_input *, uint32_t *);
-static void handle_new_sink_input(struct userdata *, struct pa_sink_input *, uint32_t *preserve_cork_state);
+static void handle_new_sink_input(struct userdata *u, struct pa_sink_input *si,
+                                  uint32_t *preserve_cork_state, uint32_t *preserve_mute_state);
 static void handle_sink_input_fixate(struct userdata *u, pa_sink_input_new_data *sinp_data);
 static void handle_removed_sink_input(struct userdata *,
                                       struct pa_sink_input *);
@@ -69,10 +73,11 @@ struct pa_sinp_evsubscr *pa_sink_input_ext_subscription(struct userdata *u)
     subscr->fixate = fixate;
     subscr->put    = put;
     subscr->unlink = unlink;
-    /* state hook is dynamically set when corking is done for the first time.
-     * This way if corking is never used, we don't need to set up the state
-     * hook. */
-    subscr->state  = NULL;
+    /* cork and mute state hooks are dynamically set when corking or muting
+     * is done for the first time. This way if corking or muting is never
+     * used, we don't need to set up the state hooks. */
+    subscr->cork_state = NULL;
+    subscr->mute_state = NULL;
 
     return subscr;
 }
@@ -84,8 +89,10 @@ void  pa_sink_input_ext_subscription_free(struct pa_sinp_evsubscr *subscr)
         pa_hook_slot_free(subscr->fixate);
         pa_hook_slot_free(subscr->put);
         pa_hook_slot_free(subscr->unlink);
-        if (subscr->state)
-            pa_hook_slot_free(subscr->state);
+        if (subscr->cork_state)
+            pa_hook_slot_free(subscr->cork_state);
+        if (subscr->mute_state)
+            pa_hook_slot_free(subscr->mute_state);
 
         pa_xfree(subscr);
     }
@@ -102,7 +109,7 @@ void pa_sink_input_ext_discover(struct userdata *u)
     pa_assert_se((idxset = u->core->sink_inputs));
 
     while ((sinp = pa_idxset_iterate(idxset, &state, NULL)) != NULL)
-        handle_new_sink_input(u, sinp, NULL);
+        handle_new_sink_input(u, sinp, NULL, NULL);
 }
 
 void  pa_sink_input_ext_rediscover(struct userdata *u)
@@ -112,6 +119,7 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
     struct pa_sink_input *sinp;
     struct pa_sink_input_ext *ext;
     uint32_t              old_corked_state;
+    uint32_t              old_muted_state;
     const char           *group_name;
     const char           *clear[3] = { PA_PROP_POLICY_GROUP, PA_PROP_POLICY_STREAM_FLAGS, NULL };
 
@@ -129,10 +137,11 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
         pa_log_debug("rediscover sink-input \"%s\"", pa_sink_input_ext_get_name(sinp));
         pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
         old_corked_state = ext->local.cork_state;
+        old_muted_state = ext->local.mute_state;
         /* First remove sink input and then re-classify. */
         handle_removed_sink_input(u, sinp);
         pa_proplist_unset_many(sinp->proplist, clear);
-        handle_new_sink_input(u, sinp, &old_corked_state);
+        handle_new_sink_input(u, sinp, &old_corked_state, &old_muted_state);
     }
 }
 
@@ -201,7 +210,8 @@ const char *pa_sink_input_ext_get_name(struct pa_sink_input *sinp)
 }
 
 
-int pa_sink_input_ext_set_volume_limit(struct pa_sink_input *sinp,
+int pa_sink_input_ext_set_volume_limit(struct userdata *u,
+                                       struct pa_sink_input *sinp,
                                        pa_volume_t limit)
 {
     pa_sink     *sink;
@@ -213,15 +223,16 @@ int pa_sink_input_ext_set_volume_limit(struct pa_sink_input *sinp,
     int          changed;
     int          i;
 
+    pa_assert(u);
     pa_assert(sinp);
     pa_assert_se((sink = sinp->sink));
 
     retval = 0;
 
     if (limit == 0)
-        pa_sink_input_set_mute(sinp, true, true);
+        pa_sink_input_ext_mute(u, sinp, true);
     else {
-        pa_sink_input_set_mute(sinp, false, true);
+        pa_sink_input_ext_mute(u, sinp, false);
 
         if (limit > PA_VOLUME_NORM)
             limit = PA_VOLUME_NORM;
@@ -372,7 +383,7 @@ static pa_hook_result_t sink_input_put(void *hook_data, void *call_data,
     struct pa_sink_input *sinp = (struct pa_sink_input *)call_data;
     struct userdata      *u    = (struct userdata *)slot_data;
 
-    handle_new_sink_input(u, sinp, NULL);
+    handle_new_sink_input(u, sinp, NULL, NULL);
 
     return PA_HOOK_OK;
 }
@@ -461,7 +472,8 @@ static struct pa_policy_group* get_group_or_classify(struct userdata *u, struct 
 
 static void handle_new_sink_input(struct userdata      *u,
                                   struct pa_sink_input *sinp,
-                                  uint32_t *preserve_cork_state)
+                                  uint32_t *preserve_cork_state,
+                                  uint32_t *preserve_mute_state)
 {
     struct      pa_policy_group *group = NULL;
     struct      pa_sink_input_ext *ext;
@@ -483,6 +495,17 @@ static void handle_new_sink_input(struct userdata      *u,
             ext->local.cork_state = update_state_flag(0,
                                                       PA_SINK_INPUT_EXT_STATE_USER,
                                                       PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp));
+#if (PULSEAUDIO_VERSION == 5)
+        if (preserve_mute_state)
+            pa_log_debug("ignoring mute state as PulseAudio version 5 doesn't have mute hook.");
+#elif (PULSEAUDIO_VERSION == 6)
+        if (preserve_mute_state)
+            ext->local.mute_state = *preserve_mute_state;
+        else
+            ext->local.mute_state = update_state_flag(0,
+                                                      PA_SINK_INPUT_EXT_STATE_USER,
+                                                      sinp->muted);
+#endif
         pa_index_hash_add(u->hsi, idx, ext);
 
         pa_policy_context_register(u, pa_policy_object_sink_input, sinp_name, sinp);
@@ -522,10 +545,10 @@ bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
                  ext->local.cork_state & PA_SINK_INPUT_EXT_STATE_POLICY ? 1 : 0,
                  cork ? "" : "un");
 
-    if (!u->ssi->state) {
+    if (!u->ssi->cork_state) {
         /* Check current sink input state and enable corking state following. */
-        u->ssi->state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_STATE_CHANGED],
-                                        PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_state_changed, (void *) u);
+        u->ssi->cork_state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_STATE_CHANGED],
+                                             PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_state_changed, (void *) u);
         ext->local.cork_state = update_state_flag(ext->local.cork_state,
                                                   PA_SINK_INPUT_EXT_STATE_USER,
                                                   sink_input_corked);
@@ -577,6 +600,92 @@ static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *sinp
 
     return PA_HOOK_OK;
 }
+
+bool pa_sink_input_ext_mute(struct userdata *u, pa_sink_input *si, bool mute)
+{
+#if (PULSEAUDIO_VERSION == 5)
+    pa_assert(u);
+    pa_assert(si);
+
+    pa_sink_input_set_mute(si, mute, true);
+
+#elif (PULSEAUDIO_VERSION == 6)
+
+    struct pa_sink_input_ext *ext;
+    bool sink_input_muting_changed = false;
+
+    pa_assert(si);
+    pa_assert(u);
+    pa_assert(u->core);
+    pa_assert(u->ssi);
+
+    pa_assert_se((ext = pa_sink_input_ext_lookup(u, si)));
+
+    pa_assert(!ext->local.ignore_mute_state_change);
+
+    pa_log_debug("sink input mute state before: user: %d policy: %d, request %smute",
+                 ext->local.mute_state & PA_SINK_INPUT_EXT_STATE_USER ? 1 : 0,
+                 ext->local.mute_state & PA_SINK_INPUT_EXT_STATE_POLICY ? 1 : 0,
+                 mute ? "" : "un");
+
+    if (!u->ssi->mute_state) {
+        /* Check current sink input mute state and enable muting state following. */
+        u->ssi->mute_state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_MUTE_CHANGED],
+                                             PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_mute_changed, (void *) u);
+        ext->local.mute_state = update_state_flag(ext->local.mute_state,
+                                                  PA_SINK_INPUT_EXT_STATE_USER,
+                                                  si->muted);
+    }
+
+    ext->local.mute_state = update_state_flag(ext->local.mute_state,
+                                              PA_SINK_INPUT_EXT_STATE_POLICY,
+                                              mute);
+
+    if (!si->muted && ext->local.mute_state) {
+        ext->local.ignore_mute_state_change = true;
+        sink_input_muting_changed = true;
+        pa_sink_input_set_mute(si, true, true);
+    } else if (si->muted && !ext->local.mute_state) {
+        ext->local.ignore_mute_state_change = true;
+        sink_input_muting_changed = true;
+        pa_sink_input_set_mute(si, false, true);
+    }
+
+    pa_log_debug("sink input mute state  after: user: %d policy: %d, %s",
+                 ext->local.mute_state & PA_SINK_INPUT_EXT_STATE_USER ? 1 : 0,
+                 ext->local.mute_state & PA_SINK_INPUT_EXT_STATE_POLICY ? 1 : 0,
+                 sink_input_muting_changed ? "updated muting" : "no change to muting");
+
+    return sink_input_muting_changed;
+#else
+#error Compiling against unsupported PulseAudio version.
+#endif
+}
+
+#if (PULSEAUDIO_VERSION == 6)
+static pa_hook_result_t sink_input_mute_changed(pa_core *c, pa_sink_input *sinp, struct userdata *u)
+{
+    struct pa_sink_input_ext *ext;
+
+    pa_assert(c);
+    pa_assert(sinp);
+    pa_assert(u);
+
+    pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
+    if (ext->local.ignore_mute_state_change) {
+        ext->local.ignore_mute_state_change = false;
+        return PA_HOOK_OK;
+    }
+
+    ext->local.mute_state = update_state_flag(ext->local.mute_state,
+                                              PA_SINK_INPUT_EXT_STATE_USER,
+                                              sinp->muted);
+
+    pa_log_debug("sink input user muting %d", sinp->muted);
+
+    return PA_HOOK_OK;
+}
+#endif
 
 static void handle_sink_input_fixate(struct userdata *u,
                                      pa_sink_input_new_data *sinp_data)

--- a/src/sink-input-ext.c
+++ b/src/sink-input-ext.c
@@ -31,10 +31,11 @@ static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *si, 
 
 static struct pa_policy_group* get_group(struct userdata *, const char *, pa_proplist *sinp_proplist, uint32_t *);
 static struct pa_policy_group* get_group_or_classify(struct userdata *, struct pa_sink_input *, uint32_t *);
-static void handle_new_sink_input(struct userdata *, struct pa_sink_input *, int *);
+static void handle_new_sink_input(struct userdata *, struct pa_sink_input *, uint32_t *preserve_cork_state);
 static void handle_sink_input_fixate(struct userdata *u, pa_sink_input_new_data *sinp_data);
 static void handle_removed_sink_input(struct userdata *,
                                       struct pa_sink_input *);
+static uint32_t update_state_flag(uint32_t flags, enum pa_sink_input_ext_state flag, bool set);
 
 struct pa_sinp_evsubscr *pa_sink_input_ext_subscription(struct userdata *u)
 {
@@ -110,7 +111,7 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
     pa_idxset            *idxset;
     struct pa_sink_input *sinp;
     struct pa_sink_input_ext *ext;
-    int                   old_corked_state;
+    uint32_t              old_corked_state;
     const char           *group_name;
     const char           *clear[3] = { PA_PROP_POLICY_GROUP, PA_PROP_POLICY_STREAM_FLAGS, NULL };
 
@@ -127,7 +128,7 @@ void  pa_sink_input_ext_rediscover(struct userdata *u)
 
         pa_log_debug("rediscover sink-input \"%s\"", pa_sink_input_ext_get_name(sinp));
         pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
-        old_corked_state = ext->local.corked_by_client;
+        old_corked_state = ext->local.cork_state;
         /* First remove sink input and then re-classify. */
         handle_removed_sink_input(u, sinp);
         pa_proplist_unset_many(sinp->proplist, clear);
@@ -460,7 +461,7 @@ static struct pa_policy_group* get_group_or_classify(struct userdata *u, struct 
 
 static void handle_new_sink_input(struct userdata      *u,
                                   struct pa_sink_input *sinp,
-                                  int *preserve_corked_by_client)
+                                  uint32_t *preserve_cork_state)
 {
     struct      pa_policy_group *group = NULL;
     struct      pa_sink_input_ext *ext;
@@ -476,10 +477,12 @@ static void handle_new_sink_input(struct userdata      *u,
         ext = pa_xmalloc0(sizeof(struct pa_sink_input_ext));
         ext->local.route = (flags & PA_POLICY_LOCAL_ROUTE) ? true : false;
         ext->local.mute  = (flags & PA_POLICY_LOCAL_MUTE ) ? true : false;
-        if (preserve_corked_by_client)
-            ext->local.corked_by_client = *preserve_corked_by_client;
+        if (preserve_cork_state)
+            ext->local.cork_state = *preserve_cork_state;
         else
-            ext->local.corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp);
+            ext->local.cork_state = update_state_flag(0,
+                                                      PA_SINK_INPUT_EXT_STATE_USER,
+                                                      PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp));
         pa_index_hash_add(u->hsi, idx, ext);
 
         pa_policy_context_register(u, pa_policy_object_sink_input, sinp_name, sinp);
@@ -500,6 +503,7 @@ static void handle_new_sink_input(struct userdata      *u,
 bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
 {
     struct pa_sink_input_ext *ext;
+    bool sink_input_corked;
     bool sink_input_corking_changed = false;
 
     pa_assert(si);
@@ -509,30 +513,42 @@ bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork)
 
     pa_assert_se((ext = pa_sink_input_ext_lookup(u, si)));
 
+    pa_assert(!ext->local.ignore_cork_state_change);
+
+    sink_input_corked = pa_sink_input_get_state(si) == PA_SINK_INPUT_CORKED;
+
+    pa_log_debug("sink input cork state before: user: %d policy: %d, request %scork",
+                 ext->local.cork_state & PA_SINK_INPUT_EXT_STATE_USER ? 1 : 0,
+                 ext->local.cork_state & PA_SINK_INPUT_EXT_STATE_POLICY ? 1 : 0,
+                 cork ? "" : "un");
+
     if (!u->ssi->state) {
         /* Check current sink input state and enable corking state following. */
         u->ssi->state = pa_hook_connect(&u->core->hooks[PA_CORE_HOOK_SINK_INPUT_STATE_CHANGED],
                                         PA_HOOK_EARLY, (pa_hook_cb_t) sink_input_state_changed, (void *) u);
-        ext->local.corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(si);
+        ext->local.cork_state = update_state_flag(ext->local.cork_state,
+                                                  PA_SINK_INPUT_EXT_STATE_USER,
+                                                  sink_input_corked);
     }
 
-    if (cork) {
-        if (!ext->local.corked_by_client) {
-            ext->local.ignore_state_change = true;
-            pa_log_debug("sink input wasn't already corked by client -> cork");
-            pa_sink_input_cork(si, true);
-            sink_input_corking_changed = true;
-        } else
-            pa_log_debug("sink input was already corked by client -> not corking");
-    } else {
-        if (!ext->local.corked_by_client) {
-            ext->local.ignore_state_change = true;
-            pa_log_debug("sink input wasn't already corked by client -> uncork");
-            pa_sink_input_cork(si, false);
-            sink_input_corking_changed = true;
-        } else
-            pa_log_debug("sink input was already corked by client -> not uncorking");
+    ext->local.cork_state = update_state_flag(ext->local.cork_state,
+                                              PA_SINK_INPUT_EXT_STATE_POLICY,
+                                              cork);
+
+    if (!sink_input_corked && ext->local.cork_state) {
+        ext->local.ignore_cork_state_change = true;
+        sink_input_corking_changed = true;
+        pa_sink_input_cork(si, true);
+    } else if (sink_input_corked && !ext->local.cork_state) {
+        ext->local.ignore_cork_state_change = true;
+        sink_input_corking_changed = true;
+        pa_sink_input_cork(si, false);
     }
+
+    pa_log_debug("sink input cork state  after: user: %d policy: %d, %s",
+                 ext->local.cork_state & PA_SINK_INPUT_EXT_STATE_USER ? 1 : 0,
+                 ext->local.cork_state & PA_SINK_INPUT_EXT_STATE_POLICY ? 1 : 0,
+                 sink_input_corking_changed ? "updated corking" : "no change to corking");
 
     return sink_input_corking_changed;
 }
@@ -547,17 +563,17 @@ static pa_hook_result_t sink_input_state_changed(pa_core *c, pa_sink_input *sinp
     pa_assert(u);
 
     pa_assert_se((ext = pa_sink_input_ext_lookup(u, sinp)));
-    if (ext->local.ignore_state_change) {
-        pa_log_debug("local state change -> IGNORE");
+    if (ext->local.ignore_cork_state_change) {
+        ext->local.ignore_cork_state_change = false;
         return PA_HOOK_OK;
     }
 
-    ext->local.ignore_state_change = false;
     corked_by_client = PA_SINK_INPUT_CORKED == pa_sink_input_get_state(sinp);
-    if (corked_by_client != ext->local.corked_by_client) {
-        pa_log_debug("corked_by_client changes to %s", corked_by_client ? "true" : "false");
-        ext->local.corked_by_client = corked_by_client;
-    }
+    ext->local.cork_state = update_state_flag(ext->local.cork_state,
+                                              PA_SINK_INPUT_EXT_STATE_USER,
+                                              corked_by_client);
+
+    pa_log_debug("sink input user corking %d", corked_by_client);
 
     return PA_HOOK_OK;
 }
@@ -630,6 +646,14 @@ static void handle_removed_sink_input(struct userdata      *u,
         pa_log_debug("removed sink_input '%s' (idx=%d) (group=%s)",
                      snam, idx, group->name);
     }
+}
+
+static uint32_t update_state_flag(uint32_t flags, enum pa_sink_input_ext_state flag, bool set)
+{
+    if (set)
+        return flags | flag;
+    else
+        return flags & ~flag;
 }
 
 /*

--- a/src/sink-input-ext.h
+++ b/src/sink-input-ext.h
@@ -17,7 +17,8 @@ struct pa_sinp_evsubscr {
     pa_hook_slot    *fixate;
     pa_hook_slot    *put;
     pa_hook_slot    *unlink;
-    pa_hook_slot    *state;
+    pa_hook_slot    *cork_state;
+    pa_hook_slot    *mute_state;
 };
 
 enum pa_sink_input_ext_state {
@@ -32,6 +33,8 @@ struct pa_sink_input_ext {
         int mute;
         uint32_t cork_state;
         bool ignore_cork_state_change;
+        uint32_t mute_state;
+        bool ignore_mute_state_change;
     }                local;     /* local policies */
 };
 
@@ -45,8 +48,9 @@ struct pa_sink_input_ext *pa_sink_input_ext_lookup(struct userdata *,
 int   pa_sink_input_ext_set_policy_group(struct pa_sink_input *, const char *);
 const char *pa_sink_input_ext_get_policy_group(struct pa_sink_input *);
 const char *pa_sink_input_ext_get_name(struct pa_sink_input *);
-int   pa_sink_input_ext_set_volume_limit(struct pa_sink_input *, pa_volume_t);
+int   pa_sink_input_ext_set_volume_limit(struct userdata *u, struct pa_sink_input *, pa_volume_t);
 bool pa_sink_input_ext_cork(struct userdata *u, pa_sink_input *si, bool cork);
+bool pa_sink_input_ext_mute(struct userdata *u, pa_sink_input *si, bool mute);
 
 #endif
 

--- a/src/sink-input-ext.h
+++ b/src/sink-input-ext.h
@@ -20,12 +20,18 @@ struct pa_sinp_evsubscr {
     pa_hook_slot    *state;
 };
 
+enum pa_sink_input_ext_state {
+    PA_SINK_INPUT_EXT_STATE_NONE    = 0,
+    PA_SINK_INPUT_EXT_STATE_USER    = 1 << 0,
+    PA_SINK_INPUT_EXT_STATE_POLICY  = 1 << 1
+};
+
 struct pa_sink_input_ext {
     struct {
         int route;
         int mute;
-        bool corked_by_client;
-        bool ignore_state_change;
+        uint32_t cork_state;
+        bool ignore_cork_state_change;
     }                local;     /* local policies */
 };
 


### PR DESCRIPTION
Proper implementation of following user mute state. We now track user
mutes and change actual muting when both policy and user agree on the
muting.